### PR TITLE
Fixes Webpack error by making path lowercase

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -1,5 +1,5 @@
 var Format = require('./Format');
-var Type = require('./Type');
+var Type = require('./type');
 var util = require('./util');
 var sfnt = require('./sfnt');
 var woff = require('./woff');

--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -1,5 +1,5 @@
 var ReadBuffer = require('../readbuffer');
-var Type = require('../Type');
+var Type = require('../type');
 var util = require('../util');
 
 var cmap = function (buffer, font) {

--- a/src/tables/common.js
+++ b/src/tables/common.js
@@ -1,4 +1,4 @@
-var Type = require('../Type');
+var Type = require('../type');
 var util = require('../util');
 
 var List = function (buffer, offset, table) {

--- a/src/tables/gasp.js
+++ b/src/tables/gasp.js
@@ -1,5 +1,5 @@
 var ReadBuffer = require('../readbuffer');
-var Type = require('../Type');
+var Type = require('../type');
 var util = require('../util');
 
 module.exports = function (buffer, font) {

--- a/src/tables/gdef.js
+++ b/src/tables/gdef.js
@@ -1,5 +1,5 @@
 var ReadBuffer = require('../readbuffer');
-var Type = require('../Type');
+var Type = require('../type');
 var util = require('../util');
 var common = require('./common');
 

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -1,5 +1,5 @@
 var ReadBuffer = require('../readbuffer');
-var Type = require('../Type');
+var Type = require('../type');
 var util = require('../util');
 var common = require('./common');
 


### PR DESCRIPTION
This fixes an error by replacing `./Type` with `./type` in the `require` statements. Webpack was getting very concerned about file systems that handle capitalisation differently!