### PR TITLE
Fixes Error: Cannot find module './Format'

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -1,4 +1,4 @@
-var Format = require('./Format');
+var Format = require('./format');
 var Type = require('./type');
 var util = require('./util');
 var sfnt = require('./sfnt');


### PR DESCRIPTION
This error happens in case sensitive systems (like linux)