### PR TITLE
sbix table parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 build

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -19,13 +19,15 @@ var post = require('./tables/post');
 var gsub = require('./tables/gsub');
 var gdef = require('./tables/gdef');
 var gasp = require('./tables/gasp');
+var sbix = require('./tables/sbix');
 
 var TABLES = {
   // Note that the order of the tables
   // is important. The `hmtx` table requires
-  // `hhea` and `maxp` tables to be parsed. The
-  // `post` table (depending on its version)
+  // `hhea` and `maxp` tables to be parsed.
+  // The `post` table (depending on its version)
   // requires the `maxp` table to be parsed.
+  // The `sbix` table requires `maxp` table to be parsed.
   'cmap': cmap,
   'head': head,
   'hhea': hhea,
@@ -36,7 +38,8 @@ var TABLES = {
   'post': post,
   'GSUB': gsub,
   'GDEF': gdef,
-  'gasp': gasp
+  'gasp': gasp,
+  'sbix': sbix
 };
 
 /**

--- a/src/tables/sbix.js
+++ b/src/tables/sbix.js
@@ -1,0 +1,64 @@
+// Specs: https://docs.microsoft.com/en-us/typography/opentype/spec/sbix
+
+var ReadBuffer = require('../readbuffer');
+var Type = require('../type');
+var util = require('../util');
+
+var SbixHeader = util.struct({
+  version: Type.USHORT,
+  flags: Type.USHORT,
+  numStrikes: Type.ULONG
+});
+
+var StrikeHeader = util.struct({
+  ppem: Type.USHORT,
+  ppi: Type.USHORT
+});
+
+var GlyphHeader = util.struct({
+  originOffsetX: Type.USHORT,
+  originOffsetY: Type.USHORT,
+  graphicType: Type.TAG
+});
+
+module.exports = function (buffer, font) {
+  var table = new ReadBuffer(buffer);
+  var data = {};
+
+  var numGlyphs = font.tables.maxp.numGlyphs;
+
+  util.extend(data, table.read(SbixHeader));
+
+  // version should be 1
+  if (data.version !== 1) return buffer;
+  // least-significant bit should be set to 1
+  if (data.flags & 1 !== 1) return buffer;
+
+  data.strikes = [];
+
+  var strikeOffsets = table.readArray(Type.ULONG, data.numStrikes);
+  strikeOffsets.forEach(function(strikeOffset) {
+    table.goto(strikeOffset);
+    var strike = table.read(StrikeHeader);
+    strike.glyphs = [];
+    var glyphDataOffsets = table.readArray(Type.ULONG, numGlyphs + 1);
+
+    for (var i = 0; i < numGlyphs; i++) {
+      var glyphDataStart = strikeOffset + glyphDataOffsets[i];
+      var glyphDataEnd = strikeOffset + glyphDataOffsets[i + 1];
+      if (glyphDataEnd - glyphDataStart >= GlyphHeader.sizeof) {
+        table.goto(glyphDataStart);
+        var glyph = table.read(GlyphHeader);
+        glyph.data = buffer.slice(glyphDataStart + GlyphHeader.sizeof, glyphDataEnd);
+        strike.glyphs.push(glyph);
+      } else {
+        strike.glyphs.push(null);
+      }
+    }
+
+    data.strikes.push(strike);
+  });
+
+  delete data.numStrikes;
+  return data;
+};

--- a/test/tables/sbix-test.js
+++ b/test/tables/sbix-test.js
@@ -1,0 +1,123 @@
+var sbix = require('../../src/tables/sbix');
+var expect = require('unexpected');
+var c = require('concentrate');
+
+describe('tables.sbix', function () {
+  it('reads sbix table with no strikes', function () {
+    var data = c()
+      .uint16be(0x0001) // version
+      .uint16be(0x0001) // flags - least-significant bit should be set to 1
+      .uint32be(0) // numStrikes
+      .result();
+
+    var font = {
+      tables: {
+        maxp: {
+          numGlyphs: 0
+        }
+      }
+    };
+
+    expect(sbix(data, font), 'to equal', {
+      version: 1,
+      flags: 1,
+      strikes: []
+    });
+  });
+
+  it('reads sbix table with strikes and no glyphs', function () {
+    var data = c()
+      .uint16be(0x0001) // version
+      .uint16be(0x0001) // flags - least-significant bit should be set to 1
+      .uint32be(2) // numStrikes
+      .uint32be(16) // offset to strike #1 (from beginning of table)
+      .uint32be(16 + 8) // offset to strike #2 (from beginning of table)
+      // strike #1
+      .uint16be(10) // ppem
+      .uint16be(72) // ppi
+      .uint32be(0) // offsets to glyphs - `maxp.numGlyphs` + 1
+      // strike #2
+      .uint16be(20) // ppem
+      .uint16be(72) // ppi
+      .uint32be(0) // offsets to glyphs - `maxp.numGlyphs` + 1
+      .result();
+
+    var font = {
+      tables: {
+        maxp: {
+          numGlyphs: 0
+        }
+      }
+    };
+
+    expect(sbix(data, font), 'to equal', {
+      version: 1,
+      flags: 1,
+      strikes: [{
+        ppem: 10,
+        ppi: 72,
+        glyphs: []
+      }, {
+        ppem: 20,
+        ppi: 72,
+        glyphs: []
+      }]
+    });
+  });
+
+  it('reads sbix table with strike with glyphs', function () {
+    var data = c()
+      .uint16be(0x0001) // version
+      .uint16be(0x0001) // flags - least-significant bit should be set to 1
+      .uint32be(1) // numStrikes
+      .uint32be(12) // offset to strike (from beginning of table)
+      // strike
+      .uint16be(10) // ppem
+      .uint16be(72) // ppi
+      // offsets to glyphs (from beginning of strike) - `maxp.numGlyphs` + 1
+      .uint32be(16) // offsets to glyph #1
+      .uint32be(16 + 12) // offsets to glyph #2
+      .uint32be(16 + 12 + 12) // offsets to first byte after last glyph
+      // array of glyphs (with valid headers and fake data)
+      // glyph #1
+      .uint16be(0) //originOffsetX
+      .uint16be(0) // originOffsetY
+      .string('test', 'utf-8') // graphicType (four characters)
+      .uint32be(0x11000011) // data
+      // glyph #2
+      .uint16be(0) //originOffsetX
+      .uint16be(0) // originOffsetY
+      .string('test', 'utf-8') // graphicType (four characters)
+      .uint32be(0x22000022) // data
+      .result();
+
+    var font = {
+      tables: {
+        maxp: {
+          numGlyphs: 2
+        }
+      }
+    };
+
+    expect(sbix(data, font), 'to equal', {
+      version: 1,
+      flags: 1,
+      strikes: [{
+        ppem: 10,
+        ppi: 72,
+        glyphs: [{
+          originOffsetX: 0,
+          originOffsetY: 0,
+          graphicType: 'test',
+          data: c().uint32be(0x11000011).result()
+        }, {
+          originOffsetX: 0,
+          originOffsetY: 0,
+          graphicType: 'test',
+          data: c().uint32be(0x22000022).result()
+        }]
+      }]
+    });
+  });
+});
+


### PR DESCRIPTION
Hi @bramstein!

Recently I was looking for a library to parse OpenType fonts (needed to exract some info from several files), and I stumbled at your project. It didn't support `sbix` tables (I needed it), but I noticed that it could be easily extended to add features I need. I already did everything I wanted, but decided to share my code.

Implementation is based on specs: https://docs.microsoft.com/en-us/typography/opentype/spec/sbix

Hope tests are good enough (usually it's not the best part of my code, sadly...)