### PR TITLE
remove deprecated zlib, use brotli exposed by node

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "unexpected-stream": "^2.0.4"
   },
   "dependencies": {
-    "brotli": "^1.2.0",
     "iconv-lite": "^0.4.13",
     "node-int64": "^0.4.0"
   }

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -5,8 +5,6 @@ var sfnt = require('./sfnt');
 var woff = require('./woff');
 var woff2 = require('./woff2');
 var ReadBuffer = require('./readbuffer');
-var zlib = require('zlib');
-var brotli = require('brotli');
 
 var cmap = require('./tables/cmap');
 var head = require('./tables/head');
@@ -101,7 +99,7 @@ var parse = function (buffer) {
     }
 
     // TODO: Upgrade to Node v6.x so we can use Buffer.from.
-    var data = new Buffer(brotli.decompress(buffer.slice(rb.byteOffset, rb.byteOffset + totalSize)));
+    var data = new Buffer(zlib.brotliDecompressSync(buffer.slice(rb.byteOffset, rb.byteOffset + totalSize)));
     var offset = 0;
 
     index.forEach(function (table) {


### PR DESCRIPTION
resolves Issue #22 **opentype package relies on deprecated `zlib` package, and `brotli` package cannot resolve `fs`**